### PR TITLE
Fix syntax in the properties of Representable

### DIFF
--- a/src/Data/Functor/Rep.hs
+++ b/src/Data/Functor/Rep.hs
@@ -77,9 +77,9 @@ import Prelude hiding (lookup)
 -- Every 'Representable' 'Functor' from Hask to Hask is a right adjoint.
 --
 -- @
--- 'tabulate' . 'index'    ≡ id
--- 'index' . 'tabulate'    ≡ id
--- 'tabulate' . 'return' f ≡ 'return' f
+-- 'tabulate' . 'index'  ≡ id
+-- 'index' . 'tabulate'  ≡ id
+-- 'tabulate' . 'return' ≡ 'return'
 -- @
 
 class Distributive f => Representable f where


### PR DESCRIPTION
An alternative here would have been to parenthesise `'tabulate' . 'return'`, but given that the other two properties are written point-free this seems the most reasonable compromise.
