### PR TITLE
Make `Functor` the superclass of `Representable`

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+4.3
+---
+* Changed the superclass constraint of `Representable` from `Distributive` to just `Functor`.
+
 4.2
 ---
 * `contravariant` 1.0 support. `Day` convolution moves to `kan-extensions`.

--- a/adjunctions.cabal
+++ b/adjunctions.cabal
@@ -1,6 +1,6 @@
 name:          adjunctions
 category:      Data Structures, Adjunctions
-version:       4.2
+version:       4.3
 license:       BSD3
 cabal-version: >= 1.6
 license-file:  LICENSE

--- a/src/Data/Functor/Rep.hs
+++ b/src/Data/Functor/Rep.hs
@@ -94,7 +94,7 @@ import Prelude hiding (lookup)
 -- 'tabulate' . 'return' ≡ 'return'
 -- @
 
-class Distributive f => Representable f where
+class Functor f => Representable f where
   type Rep f :: *
   -- |
   -- @
@@ -111,7 +111,7 @@ class Distributive f => Representable f where
 -- This can be used with the combinators from the @lens@ package.
 --
 -- @'tabulated' :: 'Representable' f => 'Iso'' ('Rep' f -> a) (f a)@
-tabulated :: (Representable f, Representable g, Profunctor p, Functor h) 
+tabulated :: (Representable f, Representable g, Profunctor p, Functor h)
           => p (f a) (h (g b)) -> p (Rep f -> a) (h (Rep g -> b))
 tabulated = dimap tabulate (fmap index)
 {-# INLINE tabulated #-}


### PR DESCRIPTION
I think we should drop the `Distributive` superclass constraint, and make it just Functor.

Any code that needs `distribute` given `Representable f` can just use `distributeRep`, and get no performance penalty, because indexing under fmap and then tabulating is the only way to implement `distribute` anyway.

So the `Distributive` superclass constraint is just an annoyance. Removing it will also make it easier to merge the TH and Generics pull requests by @bgamari. 
