### PR TITLE
Add Representable instances for new Functors in base-4.9

### DIFF
--- a/adjunctions.cabal
+++ b/adjunctions.cabal
@@ -42,6 +42,7 @@ library
   build-depends:
     array         >= 0.3.0.2 && < 0.7,
     base          >= 4       && < 5,
+    base-orphans  >= 0.5     && < 1,
     comonad       >= 4       && < 5,
     containers    >= 0.3     && < 0.6,
     contravariant >= 1       && < 2,


### PR DESCRIPTION
The sequel to [this pull request](https://github.com/ekmett/distributive/pull/13). The only tricky instance to define is `Representable Complex`. I choice `type Rep Complex = Bool`, but this is somewhat of an _ad hoc_ choice, so please review to make sure it makes sense adjunctorially.