### PR TITLE
Add GHC.Generics-based default implementation for Data.Functor.Rep.Representable

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,6 @@
 next
 ----
+* Add `GHC.Generics`-based default implementation for `Data.Functor.Rep.Representable` instances
 * Add `Data.Functor.Rep.Representable` instances for `Backwards`, `Reverse`, and the datatypes in `GHC.Generics`.
 * Add `Data.Functor.Contravariant.Rep.Representable` instances for `U1` and `(:*:)` from `GHC.Generics`
 * Add `collectRep` and `imapRep` functions to `Data.Functor.Rep`.

--- a/src/Data/Functor/Rep.hs
+++ b/src/Data/Functor/Rep.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -fenable-rewrite-rules #-}
 ----------------------------------------------------------------------
 -- |
@@ -112,7 +114,14 @@ class Distributive f => Representable f where
   -- 'fmap' f . 'tabulate' ≡ 'tabulate' . 'fmap' f
   -- @
   tabulate :: (Rep f -> a) -> f a
+  default tabulate :: (Gen.Generic1 f, Rep (Gen.Rep1 f) ~ Rep f, Representable (Gen.Rep1 f))
+                   => (Rep f -> a) -> f a
+  tabulate = Gen.to1 . tabulate
+
   index    :: f a -> Rep f -> a
+  default index :: (Gen.Generic1 f, Rep (Gen.Rep1 f) ~ Rep f, Representable (Gen.Rep1 f))
+                => f a -> Rep f -> a
+  index = index . Gen.from1
 
 {-# RULES
 "tabulate/index" forall t. tabulate (index t) = t #-}
@@ -352,3 +361,24 @@ liftR2 f fa fb = tabulate $ \i -> f (index fa i) (index fb i)
 
 liftR3 :: Representable f => (a -> b -> c -> d) -> f a -> f b -> f c -> f d
 liftR3 f fa fb fc = tabulate $ \i -> f (index fa i) (index fb i) (index fc i)
+
+instance (Representable a, Representable b, Distributive (a Gen.:*: b)) => Representable (a Gen.:*: b) where
+  type Rep (a Gen.:*: b) = Either (Rep a) (Rep b)
+  tabulate f = tabulate (f . Left) Gen.:*: tabulate (f . Right)
+  index (a Gen.:*: _) (Left i)  = index a i
+  index (_ Gen.:*: b) (Right i) = index b i
+
+instance Distributive Gen.Par1 => Representable Gen.Par1 where
+  type Rep Gen.Par1 = ()
+  tabulate f = Gen.Par1 $ f ()
+  index (Gen.Par1 x) () = x
+
+instance (Representable f, Distributive (Gen.Rec1 f)) => Representable (Gen.Rec1 f) where
+  type Rep (Gen.Rec1 f) = Rep f
+  tabulate f = Gen.Rec1 $ tabulate f
+  index (Gen.Rec1 x) i = index x i
+
+instance (Representable f, Distributive (Gen.M1 i c f)) => Representable (Gen.M1 i c f) where
+  type Rep (Gen.M1 i c f) = Rep f
+  tabulate f = Gen.M1 $ tabulate f
+  index = index

--- a/src/Data/Functor/Rep.hs
+++ b/src/Data/Functor/Rep.hs
@@ -97,7 +97,6 @@ import qualified Data.Sequence as Seq
 import Data.Semigroup hiding (Product)
 import Data.Tagged
 import Data.Void
-import qualified GHC.Generics as Gen
 import GHC.Generics hiding (Rep)
 import Prelude hiding (lookup)
 
@@ -125,13 +124,13 @@ class Distributive f => Representable f where
   --
   -- If no definition is provided, this will default to 'gtabulate'.
   tabulate :: (Rep f -> a) -> f a
-  default tabulate :: (Gen.Generic1 f, GRep f ~ Rep f, GTabulate (Gen.Rep1 f))
+  default tabulate :: (Generic1 f, GRep f ~ Rep f, GTabulate (Rep1 f))
                    => (Rep f -> a) -> f a
   tabulate = gtabulate
 
   -- | If no definition is provided, this will default to 'gindex'.
   index    :: f a -> Rep f -> a
-  default index :: (Gen.Generic1 f, GRep f ~ Rep f, GIndex (Gen.Rep1 f))
+  default index :: (Generic1 f, GRep f ~ Rep f, GIndex (Rep1 f))
                 => f a -> Rep f -> a
   index = gindex
 
@@ -151,17 +150,17 @@ class Distributive f => Representable f where
 -- @
 --
 -- (See the Haddocks for 'WrappedRep' for an explanation of its purpose.)
-type GRep f = GRep' (Gen.Rep1 f)
+type GRep f = GRep' (Rep1 f)
 
 -- | A default implementation of 'tabulate' in terms of 'GRep'.
-gtabulate :: (Gen.Generic1 f, GRep f ~ Rep f, GTabulate (Gen.Rep1 f))
+gtabulate :: (Generic1 f, GRep f ~ Rep f, GTabulate (Rep1 f))
           => (Rep f -> a) -> f a
-gtabulate = Gen.to1 . gtabulate'
+gtabulate = to1 . gtabulate'
 
 -- | A default implementation of 'index' in terms of 'GRep'.
-gindex :: (Gen.Generic1 f, GRep f ~ Rep f, GIndex (Gen.Rep1 f))
+gindex :: (Generic1 f, GRep f ~ Rep f, GIndex (Rep1 f))
        => f a -> Rep f -> a
-gindex = gindex' . Gen.from1
+gindex = gindex' . from1
 
 type family GRep' (f :: * -> *) :: *
 class GTabulate f where

--- a/src/Data/Functor/Rep.hs
+++ b/src/Data/Functor/Rep.hs
@@ -177,7 +177,7 @@ instance (GIndex f, GIndex g) => GIndex (f :*: g) where
 
 type instance GRep' (f :.: g) = (WrappedRep f, GRep' g)
 instance (Representable f, GTabulate g) => GTabulate (f :.: g) where
-  gtabulate' = Comp1 . tabulate . fmap gtabulate' . flip fmap WrapRep . curry
+  gtabulate' f = Comp1 $ tabulate $ fmap gtabulate' $ fmap (curry f) WrapRep
 instance (Representable f, GIndex g) => GIndex (f :.: g) where
   gindex' (Comp1 fg) (i, j) = gindex' (index fg (unwrapRep i)) j
 

--- a/src/Data/Functor/Rep.hs
+++ b/src/Data/Functor/Rep.hs
@@ -94,6 +94,7 @@ import Data.Tagged
 import Data.Void
 import GHC.Generics hiding (Rep)
 import Prelude hiding (lookup)
+import qualified GHC.Generics as Gen
 
 -- | A 'Functor' @f@ is 'Representable' if 'tabulate' and 'index' witness an isomorphism to @(->) x@.
 --
@@ -109,6 +110,8 @@ import Prelude hiding (lookup)
 
 class Distributive f => Representable f where
   type Rep f :: *
+  type Rep f = Rep (Gen.Rep1 f)
+
   -- |
   -- @
   -- 'fmap' f . 'tabulate' ≡ 'tabulate' . 'fmap' f


### PR DESCRIPTION
A modern attempt at #12.

cc @treeowl.