### PR TITLE
Coerce all the Representable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ wip
 *.hi
 *~
 *#
+.stack-work/


### PR DESCRIPTION
* Implement lots of `Representable` instances for newtypes using
coercions for efficiency.

* Use `collectRep` to implement `collect` for `Co`.

* Add `.stack-work` to `.gitignore`.