### PR TITLE
Add Semigroup and Monoid instances for Co

### DIFF
--- a/src/Data/Functor/Rep.hs
+++ b/src/Data/Functor/Rep.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE Trustworthy #-}
-{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -fenable-rewrite-rules #-}
 ----------------------------------------------------------------------
 -- |
@@ -434,6 +433,13 @@ instance Representable f => Representable (M1 i c f) where
   tabulate = M1 #. tabulate
 
 newtype Co f a = Co { unCo :: f a } deriving Functor
+
+instance (Representable f, Semigroup a) => Semigroup (Co f a) where
+  Co a <> Co b = Co . tabulate $ index a <> index b
+
+instance (Representable f, Semigroup a, Monoid a) => Monoid (Co f a) where
+  mempty = Co (tabulate (const mempty))
+  mappend = (<>)
 
 instance Representable f => Representable (Co f) where
   type Rep (Co f) = Rep f


### PR DESCRIPTION
There's a sensible Monoid for `(Representable f, Monoid a) => f a`, To `mappend` two representables we simple `mappend` the value in each 'slot'. `mempty` is simply `tabulate (const mempty)`.

I found this Monoid quite useful when using [Representable for types of discrimination](http://chrispenner.ca/posts/representable-discrimination).

I've added this instance for the `Co` wrapper.

Let me know if there's anything else this would need, or if it's not in line with your ideas.

Thanks for everything you do Edward!

Cheers