### PR TITLE
Improve asymptotics of Representable for instances without random access

### DIFF
--- a/src/Data/Functor1.hs
+++ b/src/Data/Functor1.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE CPP        #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Data.Functor1 where
+
+import Control.Applicative (Const(..))
+import Data.Functor.Identity
+import Data.Proxy
+
+class Functor1 w where
+  -- | @
+  -- 'map1' f . 'map1' g = 'map1' (f . g)
+  -- 'map1' id = id
+  -- @
+  map1 :: (forall a. f a -> g a) -> w f -> w g
+
+map1Identity :: Functor1 w => (forall x. f x -> x) -> w f -> w Identity
+map1Identity f = map1 (Identity . f)
+
+instance Functor1 Proxy where
+  map1 _ Proxy = Proxy
+
+#if MIN_VERSION_base(4,9,0)
+instance Functor1 (Const a) where
+  map1 _ = Const . getConst
+#endif

--- a/src/Data/Functor1/Applied.hs
+++ b/src/Data/Functor1/Applied.hs
@@ -1,0 +1,8 @@
+module Data.Functor1.Applied where
+
+import Data.Functor1
+
+newtype Applied a f = Applied { runApplied :: f a }
+
+instance Functor1 (Applied a) where
+  map1 f = Applied . f . runApplied


### PR DESCRIPTION
Representable is currently inefficient for instances which don't have O(1) `index`, such as `Stream` and `Cofree`. E.g. zipping two streams with `mzipRep` is at best O(n^2). This PR adds new methods which are equal in power to `tabulate` and `index` for an existential `Rep`, but which don't rely on indexing and thus can be asymptotically faster. The new methods are more powerful versions of those in `Distributive`, with the simplest one being:

```haskell
distribute1 :: forall w. Functor1 w => w f -> f (w Identity)
```

where a `Functor1` is a functor of kind `(* -> *) -> *`:

```haskell
class Functor1 w where
  map1 :: (forall a. f a -> g a) -> w f -> w g
```

By using `Functor1` instead of `Functor`, `distribute1` allows zipping of containers with different element types, unlike `distribute` which can only zip containers with elements of the same type. E.g. `distribute1` is powerful enough to implement `mzipRep`, by instantiating `w` with `PairOf a b`:

```haskell
data PairOf a b f = PairOf (f a) (f b)
instance Functor1 (PairOf a b) where
  map1 f (PairOf as bs) = PairOf (f as) (f bs)

mzipRep :: Representable f => f a -> f b -> f (a, b)
mzipRep as bs = fmap f $ distribute1 $ PairOf as bs
  where f (PairOf (Identity a) (Identity b)) = (a, b)
```

In fact, `distribute1` (plus `fmap`) is powerful enough to derive `Representable`, by selecting
`Rep f = Logarithm f` where:

```haskell
newtype Logarithm f = Logarithm { runLogarithm :: forall x. f x -> x }
```

with the idea being that an index can just be defined to be a function which gets the element at that index.

So `distribute1` is equal in power to `tabulate` and `index` when one doesn't care what the value of `Rep` is. Yet `distribute1` can be asymptotically faster for instances without random access. E.g. the above implementation of `mzipRep` can be O(n) for streams, given an appropriate implementation of `distribute1`:

```haskell
data Stream a = Cons { head :: a, tail :: Stream a }

distribute1 :: Functor1 w => w (Stream a) -> Stream (w Identity)
distribute1 w = map1 (Identity . head) w `Cons` distribute1 (map1 tail w)
```

I didn't include it in this PR since it would be a potentially breaking change, but it's probably also worth considering changing the defaults of the class so that `Rep` defaults to `Logarithm`.