### PR TITLE
Define "as <* _ = as" and "_ *> bs = bs"

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,8 @@
 next [????.??.??]
 -----------------
+* `(<*)` and `(*>)` of `Applicative (Co f)` are implemented in _O(1)_
+  by defining them as constant functions `as <* _ = as` and `_ *> bs =
+  bs`. This implementation follows from the laws of `Representable`.
 * Use more concise `MINIMAL` defaults for the `Adjunction` classes.
 * TODO: Describe `cotraverse1`-related changes
 * The dependencies on `semigroups` and `void` are both now conditional

--- a/src/Data/Functor/Rep.hs
+++ b/src/Data/Functor/Rep.hs
@@ -612,6 +612,17 @@ instance Representable f => Applicative (Co f) where
   pure = pureRep
   (<*>) = apRep
 
+  -- | This method is /O(1)/. 'Representable' functors are isomorphic
+  -- to functions and '<*' for functions drops its second argument and
+  -- returns its first.
+  as <* _  = as
+  -- | This method is /O(1)/. 'Representable' functors are isomorphic
+  -- to functions and '*>' for functions drops its first argument and
+  -- returns its first.
+  _  *> bs = bs
+
+  -- See issue #64: <https://github.com/ekmett/adjunctions/issues/64>
+
 instance Representable f => Distributive (Co f) where
   distribute = distributeRep
   collect = collectRep


### PR DESCRIPTION
Define `as <* _ = as` and `_ *> bs = bs` in *O(1)* for `Applicative (Co f)`.

This is justified by the Representable laws.

Fixes issue #64.