### PR TITLE
Add PolyKinds to Data.Functor.Rep

### DIFF
--- a/adjunctions.cabal
+++ b/adjunctions.cabal
@@ -53,7 +53,7 @@ library
     comonad             >= 4       && < 6,
     containers          >= 0.3     && < 0.7,
     contravariant       >= 1       && < 2,
-    distributive        >= 0.5.1   && < 1,
+    distributive        >= 0.6.2   && < 1,
     free                >= 4       && < 6,
     mtl                 >= 2.0.1   && < 2.3,
     profunctors         >= 4       && < 6,

--- a/src/Data/Functor/Rep.hs
+++ b/src/Data/Functor/Rep.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -11,6 +10,11 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE Trustworthy #-}
+
+#if __GLASGOW_HASKELL__ >= 706 ... #endif
+{-# LANGUAGE PolyKinds #-}
+#endif
+
 {-# OPTIONS_GHC -fenable-rewrite-rules #-}
 ----------------------------------------------------------------------
 -- |

--- a/src/Data/Functor/Rep.hs
+++ b/src/Data/Functor/Rep.hs
@@ -11,7 +11,7 @@
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE Trustworthy #-}
 
-#if __GLASGOW_HASKELL__ >= 706 ... #endif
+#if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
 #endif
 

--- a/src/Data/Functor/Rep.hs
+++ b/src/Data/Functor/Rep.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}


### PR DESCRIPTION
Currently `Rep (Tagged a)` only works for `a :: Type`, but `Tagged (a :: k)`.