### PR TITLE
Import fix from Data.Function instead of Control.Monad.Reader

### DIFF
--- a/src/Data/Functor/Rep.hs
+++ b/src/Data/Functor/Rep.hs
@@ -106,6 +106,7 @@ import Data.Complex
 #endif
 import Data.Distributive
 import Data.Foldable (Foldable(fold))
+import Data.Function
 import Data.Functor.Bind
 import Data.Functor.Identity
 import Data.Functor.Compose


### PR DESCRIPTION
There is an intention to stop re-exporting functions from `base` in future versions of `mtl`: https://github.com/haskell/mtl/pull/74
This PR brings `adjunctions` in line with the proposed change, because at the moment `Data.Functor.Rep` exports `fix` (originally from `Data.Function`) from `Control.Monad.Reader`.